### PR TITLE
Update Netlify deployment example to latest Prisma versions (including shadowDatabaseUrl and a CSS fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "netlify-cli": "3.37.1",
-    "prisma": "^3.14.0"
+    "netlify-cli": "12.2.9",
+    "prisma": "^4.7.1"
   },
   "scripts": {
     "build": "prisma generate",
     "dev": "netlify dev"
   },
   "dependencies": {
-    "@prisma/client": "^3.14.0"
+    "@prisma/client": "^4.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "prisma": "2.24.1",
-    "netlify-cli": "3.37.1"
+    "netlify-cli": "3.37.1",
+    "prisma": "^3.14.0"
   },
   "scripts": {
     "build": "prisma generate",
     "dev": "netlify dev"
   },
   "dependencies": {
-    "@prisma/client": "2.24.1"
+    "@prisma/client": "^3.14.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,8 +4,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model Post {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,9 +4,8 @@ generator client {
 }
 
 datasource db {
-  provider          = "postgresql"
-  url               = env("DATABASE_URL")
-  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model Post {

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <title>Prisma example with Netlify</title>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/tailwindcss/dist/tailwind.min.css"
+      href="https://www.unpkg.com/browse/tailwindcss@0.7.4/dist/tailwind.min.css"
     />
     <style type="text/css">
       .loader,

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <title>Prisma example with Netlify</title>
     <link
       rel="stylesheet"
-      href="https://www.unpkg.com/browse/tailwindcss@0.7.4/dist/tailwind.min.css"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@0.7.4/dist/tailwind.min.css"
     />
     <style type="text/css">
       .loader,


### PR DESCRIPTION
Background:
When you go through the current published version of the Deploying to Netlify guide in the Prisma docs, things don't work as documented. To resolve the issues, several fixes are needed:

* Update Prisma and Prisma Client to latest versions (e.g. 3.14)
* Include the shadowDatabaseUrl to schema.prisma - this is due to the fact that the guide suggests that users go to Heroku as a database provider and `prisma migrate dev` requires the permissions to create a shadow database which cloud database providers do not generally allow and therefore users need to create a new database for that purpose manually
* The app CSS no longer seems to work. Changing the CSS CDN from unpkg.com to jsdelivr resolves the issue.